### PR TITLE
thumbnailer/data/download.sh: create target dir if missing

### DIFF
--- a/tasks/tiatoolbox_wsi_thumbnailer/data/download.sh
+++ b/tasks/tiatoolbox_wsi_thumbnailer/data/download.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Create the wsis/ directory if it doesn't exist
+mkdir -p wsis
+
 # Download large files required for the task
 tail -n +2 tcga_read_gdc_manifest.2025-04-26.151110_small_batch.txt | \
 while IFS=$'\t' read -r uuid filename md5 size state; do


### PR DESCRIPTION
This is a one-line safety fix (`mkdir -p wsis`) for the previously merged tiatoolbox_wsi_thumbnailer task (#8) to ensure the download target directory exists before fetching files.
